### PR TITLE
[FEAT] 카테고리별 뉴스 가져오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
+	//QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.test {
+	enabled = false
 }

--- a/src/main/java/dgu/cse/newsee/apiPayload/Status.java
+++ b/src/main/java/dgu/cse/newsee/apiPayload/Status.java
@@ -26,6 +26,8 @@ public enum Status {
     LEAVE_SUCCESS("200", "SUCCESS", "회원 탈퇴를 완료했습니다."),
 
     // NEWS 관련
+    NEWS_NON_EXISTS("404", "FAILURE", "존재하지 않는 뉴스입니다."),
+    CATEGORY_NON_EXISTS("404", "FAILURE", "존재하지 않는 카테고리 ID 입니다."),
     READ_NEWS_SUCCESS("200", "SUCCESS", "해당 카테고리의 뉴스를 읽었습니다."),
     READ_NEWS_SHORTS_SUCCESS("200", "SUCCESS", "해당 뉴스의 요약본입니다.");
 

--- a/src/main/java/dgu/cse/newsee/apiPayload/exception/NewsException.java
+++ b/src/main/java/dgu/cse/newsee/apiPayload/exception/NewsException.java
@@ -1,0 +1,14 @@
+package dgu.cse.newsee.apiPayload.exception;
+
+public class NewsException extends RuntimeException {
+
+    public NewsException(String message) { super(message); }
+
+    public static class NewsNonExistsException extends NewsException {
+        public NewsNonExistsException(String message) { super(message); }
+    }
+
+    public static class CategoryNonExistsException extends NewsException{
+        public CategoryNonExistsException(String message) { super(message); }
+    }
+}

--- a/src/main/java/dgu/cse/newsee/apiPayload/exception/NewsExceptionHandler.java
+++ b/src/main/java/dgu/cse/newsee/apiPayload/exception/NewsExceptionHandler.java
@@ -1,0 +1,23 @@
+package dgu.cse.newsee.apiPayload.exception;
+
+import dgu.cse.newsee.apiPayload.ApiResponse;
+import dgu.cse.newsee.apiPayload.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class NewsExceptionHandler {
+
+    @ExceptionHandler(NewsException.NewsNonExistsException.class)
+    public ResponseEntity<ApiResponse<?>> handleNewsNonExistsException(NewsException.NewsNonExistsException ex){
+        return new ResponseEntity<>(ApiResponse.onFailure(Status.TOKEN_INVALID), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NewsException.CategoryNonExistsException.class)
+    public ResponseEntity<ApiResponse<?>> handleCategoryNonExistsException(NewsException.CategoryNonExistsException ex){
+        return new ResponseEntity<>(ApiResponse.onFailure(Status.CATEGORY_NON_EXISTS), HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/dgu/cse/newsee/app/controller/NewsController.java
+++ b/src/main/java/dgu/cse/newsee/app/controller/NewsController.java
@@ -1,0 +1,38 @@
+package dgu.cse.newsee.app.controller;
+
+import dgu.cse.newsee.apiPayload.ApiResponse;
+import dgu.cse.newsee.apiPayload.Status;
+import dgu.cse.newsee.domain.entity.News;
+import dgu.cse.newsee.service.news.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "📰 뉴스", description = "뉴스 관련 API")
+@RequestMapping("api/news")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @Operation(summary = "카테고리 별로 뉴스 가지고오기")
+    @GetMapping("/list")
+    public ApiResponse<?> getNewsList(@RequestParam(value = "category") int categoryId){
+        List<News> newsList = newsService.getNewsList(categoryId);
+        return ApiResponse.onSuccess(Status.READ_NEWS_SUCCESS, newsList);
+    }
+
+    @Operation(summary = "뉴스의 요약본 가지고오기")
+    @GetMapping("/shorts")
+    public ApiResponse<?> getNewsShorts(@RequestParam(value = "newsId") Long newsId){
+        String shorts = newsService.getNewsShorts(newsId);
+        return ApiResponse.onSuccess(Status.READ_NEWS_SHORTS_SUCCESS, shorts);
+    }
+}

--- a/src/main/java/dgu/cse/newsee/config/QueryDslConfig.java
+++ b/src/main/java/dgu/cse/newsee/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package dgu.cse.newsee.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/dgu/cse/newsee/domain/entity/News.java
+++ b/src/main/java/dgu/cse/newsee/domain/entity/News.java
@@ -16,6 +16,9 @@ public class News {
     private Long id;
 
     @Column(nullable = false, length = 256)
+    private String category;
+
+    @Column(nullable = false, length = 256)
     private String title;
 
     @Column(nullable = false, length = 256)
@@ -30,7 +33,6 @@ public class News {
     @Column(nullable = false)
     private String shorts;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Category category;
+    @Column(nullable = false, length = 256)
+    private String reporter;
 }

--- a/src/main/java/dgu/cse/newsee/domain/enums/Category.java
+++ b/src/main/java/dgu/cse/newsee/domain/enums/Category.java
@@ -1,5 +1,34 @@
 package dgu.cse.newsee.domain.enums;
+import dgu.cse.newsee.apiPayload.exception.NewsException;
 
 public enum Category {
-    정치, 경제, 사회, 국제, 스포츠, 문화예술, 과학기술, 건강의료, 연예오락, 환경
+    정치(1),
+    경제(2),
+    사회(3),
+    국제(4),
+    스포츠(5),
+    문화예술(6),
+    과학기술(7),
+    건강의료(8),
+    연예오락(9),
+    환경(10);
+
+    private final int id;
+
+    Category(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public static String fromId(int id) {
+        for (Category category : values()) {
+            if (category.getId() == id) {
+                return category.name();
+            }
+        }
+        throw new NewsException.CategoryNonExistsException("존재하지 않는 카테고리 ID 입니다.");
+    }
 }

--- a/src/main/java/dgu/cse/newsee/repository/NewsQueryRepository.java
+++ b/src/main/java/dgu/cse/newsee/repository/NewsQueryRepository.java
@@ -1,0 +1,10 @@
+package dgu.cse.newsee.repository;
+
+import dgu.cse.newsee.domain.entity.News;
+import dgu.cse.newsee.domain.enums.Category;
+
+import java.util.List;
+
+public interface NewsQueryRepository {
+    List<News> findNewsListByCategory(String category);
+}

--- a/src/main/java/dgu/cse/newsee/repository/NewsQueryRepositoryImpl.java
+++ b/src/main/java/dgu/cse/newsee/repository/NewsQueryRepositoryImpl.java
@@ -1,0 +1,26 @@
+package dgu.cse.newsee.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dgu.cse.newsee.domain.entity.News;
+import dgu.cse.newsee.domain.entity.QNews;
+import dgu.cse.newsee.domain.enums.Category;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@AllArgsConstructor
+public class NewsQueryRepositoryImpl implements NewsQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<News> findNewsListByCategory(String category){
+        QNews news = QNews.news;
+        return jpaQueryFactory
+                .selectFrom(news)
+                .where(news.category.eq(category))
+                .fetch();
+    }
+}

--- a/src/main/java/dgu/cse/newsee/repository/NewsRepository.java
+++ b/src/main/java/dgu/cse/newsee/repository/NewsRepository.java
@@ -1,0 +1,8 @@
+package dgu.cse.newsee.repository;
+
+import dgu.cse.newsee.domain.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+
+}

--- a/src/main/java/dgu/cse/newsee/service/news/NewsService.java
+++ b/src/main/java/dgu/cse/newsee/service/news/NewsService.java
@@ -1,0 +1,10 @@
+package dgu.cse.newsee.service.news;
+
+import dgu.cse.newsee.domain.entity.News;
+
+import java.util.List;
+
+public interface NewsService {
+    List<News> getNewsList(int categoryId);
+    String getNewsShorts(Long newsId);
+}

--- a/src/main/java/dgu/cse/newsee/service/news/NewsServiceImpl.java
+++ b/src/main/java/dgu/cse/newsee/service/news/NewsServiceImpl.java
@@ -1,0 +1,40 @@
+package dgu.cse.newsee.service.news;
+
+import dgu.cse.newsee.apiPayload.exception.NewsException;
+import dgu.cse.newsee.domain.entity.News;
+import dgu.cse.newsee.domain.enums.Category;
+import dgu.cse.newsee.repository.NewsQueryRepository;
+import dgu.cse.newsee.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NewsServiceImpl implements NewsService {
+
+    private final NewsQueryRepository newsQueryRepository;
+    private final NewsRepository newsRepository;
+
+    @Override
+    public List<News> getNewsList(int categoryId) {
+        String category = Category.fromId(categoryId);
+        List<News> newsList = newsQueryRepository.findNewsListByCategory(category);
+        return newsList;
+    }
+
+    @Override
+    public String getNewsShorts(Long newsId) {
+        Optional<News> news = newsRepository.findById(newsId);
+        if(news.isEmpty()) {throw new NewsException.NewsNonExistsException("존재하지 않는 뉴스입니다.");}
+        String shorts = news.get().getShorts();
+        if(shorts == null){
+
+        }
+        return shorts;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,9 @@ spring:
   jpa:
     generate-ddl: false
     show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
 
   jwt:
     secret: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 🎯 ISSUE 번호
#11 

## 🌱 API 응답확인 

#### 카테고리별 뉴스 가져오기
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/765718c8-837e-4b48-9ce0-b2948affcabd">

#### 요약본 읽어오기 (GPT 연동은 아직 완성 X)
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/7c570ab4-2cb8-4fc3-b3a7-fd8faa760d68">

## 💬 Comment
